### PR TITLE
More QNX build fixes

### DIFF
--- a/tests/wscript
+++ b/tests/wscript
@@ -20,6 +20,8 @@ def build(bld):
 	        prog.includes = ['..','../macosx', '../posix', '../common/jack', '../common']
         if bld.env['IS_LINUX']:
 	        prog.includes = ['..','../linux', '../posix', '../common/jack', '../common']
+        if bld.env['IS_QNX']:
+	        prog.includes = ['..','../qnx', '../posix', '../common/jack', '../common']
         if bld.env['IS_SUN']:
 	        prog.includes = ['..','../solaris', '../posix', '../common/jack', '../common']
         prog.source = test_program_sources

--- a/wscript
+++ b/wscript
@@ -525,6 +525,15 @@ def configure(conf):
     else:
         conf.env['BUILD_JACKD'] = True
 
+    path = os.path
+    if sys.platform == 'win32' and (conf.env['IS_QNX'] or conf.env['IS_LINUX']):
+        # If we are cross-compiling from Windows to a system with POSIX style filenames,
+        # we need to construct file paths using posixpath instead of os.path.  Also, we
+        # need fix PREFIX, since Waf constructed it incorrectly
+        import posixpath
+        path = posixpath
+        conf.env['PREFIX'] = os.path.splitdrive(conf.env['PREFIX'])[1].replace('\\', '/')
+
     conf.env['BINDIR'] = conf.env['PREFIX'] + '/bin'
 
     if Options.options.htmldir:
@@ -581,9 +590,9 @@ def configure(conf):
         # don't define ADDON_DIR in config.h, use the default 'jack' defined in
         # windows/JackPlatformPlug_os.h
     else:
-        conf.env['ADDON_DIR'] = os.path.normpath(os.path.join(conf.env['LIBDIR'], 'jack'))
+        conf.env['ADDON_DIR'] = path.normpath(path.join(conf.env['LIBDIR'], 'jack'))
         conf.define('ADDON_DIR', conf.env['ADDON_DIR'])
-        conf.define('JACK_LOCATION', os.path.normpath(os.path.join(conf.env['PREFIX'], 'bin')))
+        conf.define('JACK_LOCATION', path.normpath(path.join(conf.env['PREFIX'], 'bin')))
 
     if not conf.env['IS_WINDOWS']:
         conf.define('USE_POSIX_SHM', 1)


### PR DESCRIPTION
This patch adds a missing case to the tests wscript, to handle the QNX
platform.  It also adds code to the setup for the various directory
macros, to handle the case when the build is taking place on Windows,
to ensure that the directory paths still come across in POSIX format.

Change-Id: If8054284d390e40c97c8c585af2851e94275aad8